### PR TITLE
Fix links

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,27 +15,27 @@
       <h2>Full page transitions</h2>
       <ul>
         <li>
-          <a href="/basic">Basic</a>
+          <a href="/basic/">Basic</a>
           No CSS customization, browser defaults
         </li>
         <li>
-          <a href="/slide-left">Slide Left</a>
+          <a href="/slide-left/">Slide Left</a>
           All pages slide in from the right to the left
         </li>
         <li>
-          <a href="/slide-left-in-out">Slide Left In and Out</a>
+          <a href="/slide-left-in-out/">Slide Left In and Out</a>
           All pages slide in from the right to left and out to the left
         </li>
         <li>
-          <a href="/unique-page-slide">Slide In/Out Unique to Page</a>
+          <a href="/unique-page-slide/">Slide In/Out Unique to Page</a>
           Each page slides in and out in a different direction
         </li>
         <li>
-          <a href="/scale">Scale</a>
+          <a href="/scale/">Scale</a>
           Each page scales in and out
         </li>
         <li>
-          <a href="/blur">Blur</a>
+          <a href="/blur/">Blur</a>
           Each page blurs in and out
         </li>
       </ul>
@@ -43,7 +43,7 @@
       <h2>Content transitions</h2>
       <ul>
         <li>
-          <a href="/grid-item-view">Grid Item View</a>
+          <a href="/grid-item-view/">Grid Item View</a>
           A standard grid of items and a transition to and from a single item
           view
         </li>


### PR DESCRIPTION
Add trailing slashes so that this repo plays nice with servers that don’t auto-add a traling slash. As a result, using something like`npx serve .` now works fine.